### PR TITLE
Check redemption availability

### DIFF
--- a/points-slider/sweettooth-points-slider.html
+++ b/points-slider/sweettooth-points-slider.html
@@ -100,7 +100,7 @@
          * disable the 'Redeem' button.
          */ 
          var $redeemButton = $pointsSlider.find('.sweettooth-redeem-button');
-         if (SweetTooth.customer.points_balance < min || $pointsSlider.val() < 0) {
+         if (SweetTooth.customer.points_balance < min || $pointsSlider.val() === 0) {
            $redeemButton.addClass('btn--disabled');
            $redeemButton.attr('disabled', true);
          }

--- a/shopify-points-slider/sweettooth-points-slider.liquid
+++ b/shopify-points-slider/sweettooth-points-slider.liquid
@@ -100,7 +100,7 @@
          * disable the 'Redeem' button.
          */ 
          var $redeemButton = $pointsSlider.find('.sweettooth-redeem-button');
-         if (SweetTooth.customer.points_balance < min || $pointsSlider.val() == 0) {
+         if (SweetTooth.customer.points_balance < min || $pointsSlider.val() === 0) {
            $redeemButton.addClass('btn--disabled');
            $redeemButton.attr('disabled', true);
          }


### PR DESCRIPTION
As per @amceachern's comment on https://github.com/smile-io/sweettooth-storefront-js/issues/116, the 'Redeem' button is disabled by default regardless of how many points the customer has. 

Also, make sure to check that the points slider value is not 0. 