### PR TITLE
Fixing slider redeem button issue on ios mobile

### DIFF
--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -308,6 +308,7 @@
 
   .smile-points-slider .smile-redeem-button {
     height: 42px;
+    cursor: pointer;
   }
 
   .smile-points-slider .smile-reward-name {


### PR DESCRIPTION
The click handler was sometimes not being added as expected to the points slider redeem button on iOS mobile devices. It turns out this is a known issue with jquery and iOS devices. The good news is that the fix for this issue is this simple line of css.

Tested using an iphone simulator and things work as expected now.