### PR TITLE
Fixed issue where redeem button click handler was not properly retrie…

### DIFF
--- a/points-products-dropdown/sweettooth-points-products-dropdown.html
+++ b/points-products-dropdown/sweettooth-points-products-dropdown.html
@@ -141,7 +141,7 @@
         $pointsProductsDropdown.on('click', '.sweettooth-redeem-button', function() {
           var $redeemButton = $(this);
           var $selectedPointsProduct = $pointsProductsDropdown.find('.sweettooth-points-products-select :selected');
-          var pointsProductId = $selectedPointsProduct.data('id');
+          var pointsProductId = $selectedPointsProduct.val();
 
           // Start loading indicator
           $redeemButton.addClass('btn--loading');


### PR DESCRIPTION
…ving ID of selected PointsProduct

The original code expected the PointsProduct <option> elements to have a "data-id" attribute. They don't, so the code as is fails with the error "Something went wrong when purchasing PointsProduct with ID undefined."

I've adjusted this so that the code will just pull the PointsProduct ID from the selected <option> element's value attribute.