### PR TITLE
[PROD-959] Update rangetouch to fix touch event blocking on iOS

### DIFF
--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -8,7 +8,7 @@
 <!-- A third party library for improved slider functionality on mobile.
      Available at: https://rangetouch.com/. Developers are welcome to host
      this file in place of using RangeTouch's CDN. -->
-<script src="https://cdn.rangetouch.com/1.0.5/rangetouch.js"></script>
+<script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
 <!-- NOTE: Your store may not use jQuery, if not uncomment this
            script to load it on the page -->
@@ -123,6 +123,11 @@
 
           // Add slider html to the points slider container
           $pointsSlider.append(sliderHtml);
+
+          // Set up improved touch event handling on the points slider.
+          // This is wrapped in a setTimeout call to ensure the element
+          // is in the DOM before we try setting up RangeTouch on it.
+          window.setTimeout(function() { new RangeTouch('.smile-range-input'); }, 0);
 
           /**
            * Check whether the Customer can spend points or if

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -153,7 +153,10 @@
           // Add slider html to the points slider container
           $pointsSlider.append(sliderHtml);
 
-          var range = new RangeTouch('.smile-points-slider');
+          // Set up improved touch event handling on the points slider.
+          // This is wrapped in a setTimeout call to ensure the element
+          // is in the DOM before we try setting up RangeTouch on it.
+          setTimeout(function() { new RangeTouch('.smile-range-input'); }, 0);
 
           /**
            * Check whether the customer can spend points or if

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -156,7 +156,7 @@
           // Set up improved touch event handling on the points slider.
           // This is wrapped in a setTimeout call to ensure the element
           // is in the DOM before we try setting up RangeTouch on it.
-          setTimeout(function() { new RangeTouch('.smile-range-input'); }, 0);
+          window.setTimeout(function() { new RangeTouch('.smile-range-input'); }, 0);
 
           /**
            * Check whether the customer can spend points or if

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -1,7 +1,7 @@
 <!-- A third party library for improved slider functionality on mobile.
      Available at: https://rangetouch.com/. Developers are welcome to host
      this file in place of using RangeTouch's CDN. -->
-<script src="https://cdn.rangetouch.com/1.0.5/rangetouch.js"></script>
+<script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
 <script src="https://js.smile.io/v1/smile-shopify.js"></script>
 
@@ -152,6 +152,8 @@
 
           // Add slider html to the points slider container
           $pointsSlider.append(sliderHtml);
+
+          var range = new RangeTouch('.smile-points-slider');
 
           /**
            * Check whether the customer can spend points or if


### PR DESCRIPTION
### What's here?
PROD-959 reported a reoccurrence of an issue where the `Redeem` button on the points at checkout slider would become unresponsive to tap/click events. After some investigation I found that _all_ elements became unresponsive to tap/click events at that point, not just the `Redeem` button. Some digging revealed [this issue](https://github.com/sampotts/rangetouch/issues/11) with the `rangetouch` helper we were using, with the solution being to update from the previous version of the helper (v1.0.5) to v2.0.x. This PR makes that update, and adds the required new `RangeTouch` initialisation call.

### Screen grabs
These recordings are a bit laggy due to being made through BrowserStack 🤷‍♂️ 

Before this fix (note that the checkbox does not respond to being clicked after dragging the points slider):
![prod-959-before](https://user-images.githubusercontent.com/5737342/83605965-7f1a0f80-a581-11ea-85e9-dbf647477fb3.gif)

After this fix:
![prod-959-after](https://user-images.githubusercontent.com/5737342/83605983-850ff080-a581-11ea-9ba0-8fe9e2aacd3d.gif)
