### PR TITLE
Sliders - allow custom currency symbol and placement

### DIFF
--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -41,6 +41,7 @@
 
     // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
     // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'Redeem SLIDER_VALUE POINTS_LABEL' would show as 'Redeem 120 points'
     // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -21,6 +21,8 @@
   (function() {
     // Store's currency symbol
     var currencySymbol = '$';
+    // Currency placement. Can be 'before' or 'after'.
+    var currencyPlacement = 'before';
     // The name used for points in your reward program.
     var pointsLabel = 'points';
 
@@ -30,7 +32,11 @@
      * currency.
      */
     var generateFulfilledRewardNameFromValue = function(value) {
-      return currencySymbol + value + ' off';
+      if (currencyPlacement === 'before') {
+        return currencySymbol + value + ' off';
+      } else {
+        return value + ' ' + currencySymbol + ' off';
+      }
     };
 
     /**

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -11,7 +11,7 @@
 <script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
 <!-- A third party library for formatting currencies in multiple locales -->
-<script type="https://cdnjs.com/libraries/currencyformatter.js"></script>
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/currencyformatter.js/2.2.0/currencyFormatter.min.js"></script>
 
 <!-- NOTE: Your store may not use jQuery, if not uncomment this
            script to load it on the page -->
@@ -45,6 +45,11 @@
       return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
     }
 
+    // Ex: `$15 off` or `15 CAD off`
+    var translatedDiscount = function(amountFormatted) {
+      return amountFormatted + ' off';
+    }
+
     /**
      * Create a name that will exist and update under the points slider.
      * Developers should update this to reflect their reward value and
@@ -59,7 +64,7 @@
         formatted = formatted + ' ' + currencyCode;
       }
 
-      return formatted + ' off';
+      return translatedDiscount(formatted);
     };
 
     /**

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -62,25 +62,22 @@
     var translatedDiscount = 'DISCOUNT_AMOUNT off';
 
     var generateRewardNameRedeemLabel = function(min) {
-      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
-      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translateRewardNameRedeemLabel;
+      var label = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
+      return label.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
     var generatePointsBalanceHtml = function(customerPointsBalance) {
-      translatePointsBalance = translatePointsBalance.replace(
+      var html = translatePointsBalance.replace(
         'NUMBER_POINTS',
         ` <span class="smile-points-balance">' ${customerPointsBalance} '</span> `
       );
 
-      translatePointsBalance = translatePointsBalance.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translatePointsBalance;
+      return html.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
-    var generateRedeemAmountLabelHtml = function(initialSliderValue) {
-      translateRedeemPoints = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
-      translateRedeemPoints = translateRedeemPoints.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translateRedeemPoints;
+   var generateRedeemAmountLabelHtml = function(initialSliderValue) {
+      var html = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
+      return html.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
     var generateFormattedRewardValue = function(value) {

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -10,6 +10,9 @@
      this file in place of using RangeTouch's CDN. -->
 <script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
+<!-- A third party library for formatting currencies in multiple locales -->
+<script type="https://cdnjs.com/libraries/currencyformatter.js"></script>
+
 <!-- NOTE: Your store may not use jQuery, if not uncomment this
            script to load it on the page -->
 <!-- <script
@@ -20,9 +23,13 @@
 <script>
   (function() {
     // Store's currency symbol
-    var currencySymbol = '$';
-    // Currency placement. Can be 'before' or 'after'.
-    var currencyPlacement = 'before';
+    var currencyCode = 'USD';
+
+    // Store's currency display type. Can be 'symbol' or 'code'
+    // ex: 'symbol' results in "$15"
+    // ex: 'display' results in "15 USD"
+    var currencyDisplayType = 'symbol';
+
     // The name used for points in your reward program.
     var pointsLabel = 'points';
 
@@ -32,11 +39,15 @@
      * currency.
      */
     var generateFulfilledRewardNameFromValue = function(value) {
-      if (currencyPlacement === 'before') {
-        return currencySymbol + value + ' off';
-      } else {
-        return value + ' ' + currencySymbol + ' off';
+      var pattern = currencyDisplayType === 'code' ? '#,##0' : '!#,##0';
+      var opts = { currency: currencyCode, pattern: pattern };
+      var formatted = OSREC.CurrencyFormatter.format(value, opts);
+
+      if (currencyDisplayType === 'code') {
+        formatted = formatted + ' ' + currencyCode;
       }
+
+      return formatted + ' off';
     };
 
     /**

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -31,7 +31,19 @@
     var currencyDisplayType = 'symbol';
 
     // The name used for points in your reward program.
-    var pointsLabel = 'points';
+    var translatePointsLabel = 'points';
+
+    // Message when points reward has been added.
+    var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
+
+    var translateYouHave = 'You have';
+
+    var translateRedeemLabel = 'Redeem';
+
+    // Slider label for when user hasn't added enough slider points for the reward.
+    var translateRewardNameRedeemLabel = function(min, translatePointsLabel) {
+      return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
+    }
 
     /**
      * Create a name that will exist and update under the points slider.
@@ -115,8 +127,8 @@
           var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
 
           var sliderHtml = ' \
-            <div class="smile-points-balance-heading">You have <span class="smile-points-balance">' + customerPointsBalance + '</span> ' + pointsLabel + '</div> \
-            <div class="smile-redeem-amount-label">Redeem <span class="smile-slider-value">' + initialSliderValue + '</span> ' + pointsLabel + '</div> \
+            <div class="smile-points-balance-heading">' + translateYouHave + ' <span class="smile-points-balance">' + customerPointsBalance + '</span> ' + translatePointsLabel + '</div> \
+            <div class="smile-redeem-amount-label">' + translateRedeemLabel + ' <span class="smile-slider-value">' + initialSliderValue + '</span> ' + translatePointsLabel + '</div> \
             <div class="smile-form"> \
               <div class="smile-range-input-container"> \
                 <input \
@@ -132,7 +144,7 @@
               </div> \
               <div class="smile-redeem-button-container"> \
                 <button type="submit" class="smile-redeem-button btn btn-primary" disabled> \
-                  Redeem \
+                  ' + translateRedeemLabel + ' \
                 </button> \
               </div> \
             </div> \
@@ -153,7 +165,7 @@
            */
            var $redeemButton = $pointsSlider.find('.smile-redeem-button');
            if (smile.customer.points_balance < min) {
-             $pointsSlider.find('.smile-reward-name').text('You need a minimum of ' + min + ' ' + pointsLabel + ' to redeem');
+             $pointsSlider.find('.smile-reward-name').text(translateRewardNameRedeemLabel(min, translatePointsLabel));
              $redeemButton.addClass('btn--disabled');
              $redeemButton.attr('disabled', true);
            }
@@ -228,7 +240,7 @@
                * to the cart.
                */
               $pointsSlider.find('.smile-redeem-amount-label').text('');
-              $pointsSlider.find('.smile-range-input-container').text('Congrats! Your reward has been applied to the cart.');
+              $pointsSlider.find('.smile-range-input-container').text(translateRewardAppliedLabel);
             }).catch(function(err) {
               console.error('Something went wrong when purchasing PointsProduct with ID ' + pointsProductId + '.');
               $pointsSlider.find('.field').addClass('field--error');

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -30,32 +30,60 @@
     // ex: 'display' results in "15 USD"
     var currencyDisplayType = 'symbol';
 
+    // Label for main button to apply their points value after using the points slider
+    var translateRedeemLabel = 'Redeem';
+
     // The name used for points in your reward program.
     var translatePointsLabel = 'points';
 
     // Message when points reward has been added.
     var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
 
-    var translateYouHave = 'You have';
+    // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 
-    var translateRedeemLabel = 'Redeem';
+    // This phrase will have NUMBER_POINTS replaced with the number of points the customer has
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'You have NUMBER_POINTS POINTS_LABEL' would show as 'You have 120 points'
+    // Do not remove `NUMBER_POINTS` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translatePointsBalance = 'You have NUMBER_POINTS POINTS_LABEL';
 
-    // Slider label for when user hasn't added enough slider points for the reward.
-    var translateRewardNameRedeemLabel = function(min, translatePointsLabel) {
-      return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
+    // This phrase will have MINIMUM_AMOUNT replaced with the number of points the customer needs to redeem.
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.' would show as 'You need a minimum of 10 points to redeem.'
+    // Do not remove `MINIMUM_AMOUNT` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translateRewardNameRedeemLabel = 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.'
+
+    // This phrase will have DISCOUNT_AMOUNT replaced with the currency amount to be discounted.
+    // Ex: 'DISCOUNT_AMOUNT off' would show as '$15 off' or '15 CAD off' depending on your preference above.
+    // Do not remove `DISCOUNT_AMOUNT` from the phrase, this will happen automatically.
+    var translatedDiscount = 'DISCOUNT_AMOUNT off';
+
+    var generateRewardNameRedeemLabel = function(min) {
+      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
+      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translateRewardNameRedeemLabel;
     }
 
-    // Ex: `$15 off` or `15 CAD off`
-    var translatedDiscount = function(amountFormatted) {
-      return amountFormatted + ' off';
+    var generatePointsBalanceHtml = function(customerPointsBalance) {
+      translatePointsBalance = translatePointsBalance.replace(
+        'NUMBER_POINTS',
+        ` <span class="smile-points-balance">' ${customerPointsBalance} '</span> `
+      );
+
+      translatePointsBalance = translatePointsBalance.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translatePointsBalance;
     }
 
-    /**
-     * Create a name that will exist and update under the points slider.
-     * Developers should update this to reflect their reward value and
-     * currency.
-     */
-    var generateFulfilledRewardNameFromValue = function(value) {
+    var generateRedeemAmountLabelHtml = function(initialSliderValue) {
+      translateRedeemPoints = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
+      translateRedeemPoints = translateRedeemPoints.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translateRedeemPoints;
+    }
+
+    var generateFormattedRewardValue = function(value) {
       var pattern = currencyDisplayType === 'code' ? '#,##0' : '!#,##0';
       var opts = { currency: currencyCode, pattern: pattern };
       var formatted = OSREC.CurrencyFormatter.format(value, opts);
@@ -64,8 +92,12 @@
         formatted = formatted + ' ' + currencyCode;
       }
 
-      return translatedDiscount(formatted);
+      return formatted;
     };
+
+    var generateRewardName = function(formattedValue) {
+      return translatedDiscount.replace('DISCOUNT_AMOUNT', formattedValue);
+    }
 
     /**
      * This method is used to automatically apply the discount code to the cart. It
@@ -129,11 +161,13 @@
           }
 
           var rewardValue = (initialSliderValue / step) * stepRewardValue;
-          var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
+          var rewardName = generateRewardName(generateFormattedRewardValue(rewardValue));
+          var pointsBalanceHtml = generatePointsBalanceHtml(customerPointsBalance);
+          var redeemAmountLabelHtml = generateRedeemAmountLabelHtml(initialSliderValue);
 
           var sliderHtml = ' \
-            <div class="smile-points-balance-heading">' + translateYouHave + ' <span class="smile-points-balance">' + customerPointsBalance + '</span> ' + translatePointsLabel + '</div> \
-            <div class="smile-redeem-amount-label">' + translateRedeemLabel + ' <span class="smile-slider-value">' + initialSliderValue + '</span> ' + translatePointsLabel + '</div> \
+            <div class="smile-points-balance-heading">' + pointsBalanceHtml + '</div> \
+            <div class="smile-redeem-amount-label">' + redeemAmountLabelHtml + '</div> \
             <div class="smile-form"> \
               <div class="smile-range-input-container"> \
                 <input \
@@ -170,7 +204,7 @@
            */
            var $redeemButton = $pointsSlider.find('.smile-redeem-button');
            if (smile.customer.points_balance < min) {
-             $pointsSlider.find('.smile-reward-name').text(translateRewardNameRedeemLabel(min, translatePointsLabel));
+             $pointsSlider.find('.smile-reward-name').text(generateRewardNameRedeemLabel(min));
              $redeemButton.addClass('btn--disabled');
              $redeemButton.attr('disabled', true);
            }
@@ -197,7 +231,7 @@
             $pointsSlider.find('.smile-slider-value').text(sliderValue);
 
             // Update reward name based on the slider value
-            var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
+            var rewardName = generateRewardName(generateFormattedRewardValue(rewardValue));
             $pointsSlider.find('.smile-reward-name').text(rewardName);
 
             /**

--- a/bigcommerce-points-slider/smile-points-slider.html
+++ b/bigcommerce-points-slider/smile-points-slider.html
@@ -30,33 +30,40 @@
     // ex: 'display' results in "15 USD"
     var currencyDisplayType = 'symbol';
 
+    // Optional translation:
     // Label for main button to apply their points value after using the points slider
     var translateRedeemLabel = 'Redeem';
 
+    // Optional translation:
     // The name used for points in your reward program.
     var translatePointsLabel = 'points';
 
+    // Optional translation:
     // Message when points reward has been added.
     var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
 
+    // Optional translation:
     // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'Redeem SLIDER_VALUE POINTS_LABEL' would show as 'Redeem 120 points'
     // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 
+    // Optional translation:
     // This phrase will have NUMBER_POINTS replaced with the number of points the customer has
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'You have NUMBER_POINTS POINTS_LABEL' would show as 'You have 120 points'
     // Do not remove `NUMBER_POINTS` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translatePointsBalance = 'You have NUMBER_POINTS POINTS_LABEL';
 
+    // Optional translation:
     // This phrase will have MINIMUM_AMOUNT replaced with the number of points the customer needs to redeem.
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.' would show as 'You need a minimum of 10 points to redeem.'
     // Do not remove `MINIMUM_AMOUNT` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRewardNameRedeemLabel = 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.'
 
+    // Optional translation:
     // This phrase will have DISCOUNT_AMOUNT replaced with the currency amount to be discounted.
     // Ex: 'DISCOUNT_AMOUNT off' would show as '$15 off' or '15 CAD off' depending on your preference above.
     // Do not remove `DISCOUNT_AMOUNT` from the phrase, this will happen automatically.

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -32,15 +32,27 @@
     var currencyDisplayType = 'symbol';
 
     // The name used for points in your reward program.
-    var pointsLabel = 'points';
+    var translatePointsLabel = 'points';
+
+    // Error message to display if the slider errors when applying points value.
+    var translateErrorMessage = 'Something went wrong spending your points. Please try again.';
+
+    // Message when points reward has been added.
+    var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
+
+    var translateYouHave = 'You have';
+
+    var translateRedeem = 'Redeem';
+
+    // Slider label for when user hasn't added enough slider points for the reward.
+    var translateRewardNameRedeemLabel = function(min, translatePointsLabel) {
+      return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
+    }
 
     if (!pointsProductId) {
       console.error('The Smile.io pointsProductId has not been set. Please set this variable in order to show the points slider at checkout. Learn more at https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout.');
       return;
     }
-
-    // The name used for points in your reward program.
-    var pointsLabel = 'points';
 
     /**
      * Build up the order summary section for our points slider to live in.
@@ -52,7 +64,7 @@
 
       var sliderContainerHtml = ' \
         <div class="order-summary__section order-summary__section--smile-points-slider"> \
-          <h3 class="smile-points-balance-heading">You have <span class="smile-points-balance">' + customerPointsBalance + '</span> ' + pointsLabel + '</h3> \
+          <h3 class="smile-points-balance-heading">' + translateYouHave + '<span class="smile-points-balance">' + customerPointsBalance + '</span> ' + translatePointsLabel + '</h3> \
           <div class="smile-points-slider" \
             data-points-product-id=' + pointsProductId + ' \
           ></div> \
@@ -140,7 +152,7 @@
           var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
 
           var sliderHtml = ' \
-            <div class="smile-redeem-amount-label">Redeem <span class="smile-slider-value">' + initialSliderValue + '</span> ' + pointsLabel + '</div> \
+            <div class="smile-redeem-amount-label">' + translateRedeem + '<span class="smile-slider-value">' + initialSliderValue + '</span> ' + translatePointsLabel + '</div> \
             <div class="fieldset"> \
               <div class="field"> \
                 <div class="smile-form"> \
@@ -158,13 +170,13 @@
                   </div> \
                   <div class="smile-redeem-button-container"> \
                     <button type="submit" class="smile-redeem-button field__input-btn btn btn--default"> \
-                      <span class="btn__content">Redeem</span> \
+                      <span class="btn__content">' + translateRedeem + '</span> \
                       <i class="btn__content shown-on-mobile icon icon--arrow"></i> \
                       <i class="btn__spinner icon icon--button-spinner"></i> \
                     </button> \
                   </div> \
                 </div> \
-                <p class="field__message field__message--error smile-points-slider-error">Something went wrong spending your points. Please try again.</p> \
+                <p class="field__message field__message--error smile-points-slider-error">' + translateErrorMessage + '</p> \
               </div> \
             </div> \
             ';
@@ -185,7 +197,7 @@
            var $redeemButton = $pointsSlider.find('.smile-redeem-button');
            var customerPointsBalance = smile.customer.points_balance;
            if (customerPointsBalance < min) {
-             $pointsSlider.find('.smile-reward-name').text('You need a minimum of ' + min + ' ' + pointsLabel + ' to redeem');
+             $pointsSlider.find('.smile-reward-name').text(translateRewardNameRedeemLabel(min, translatePointsLabel));
              $redeemButton.addClass('btn--disabled');
              $redeemButton.attr('disabled', true);
            }
@@ -260,7 +272,7 @@
                * to the cart.
                */
               $pointsSlider.find('.smile-redeem-amount-label').text('');
-              $pointsSlider.find('.smile-range-input-container').text('Congrats! Your reward has been applied to the cart.')
+              $pointsSlider.find('.smile-range-input-container').text(translateRewardAppliedLabel)
             }).catch(function(err) {
               console.error('Something went wrong when purchasing PointsProduct with ID ' + pointsProductId + '.');
               $pointsSlider.find('.field').addClass('field--error');

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -64,25 +64,22 @@
     var translatedDiscount = 'DISCOUNT_AMOUNT off';
 
     var generateRewardNameRedeemLabel = function(min) {
-      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
-      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translateRewardNameRedeemLabel;
+      var label = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
+      return label.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
     var generatePointsBalanceHtml = function(customerPointsBalance) {
-      translatePointsBalance = translatePointsBalance.replace(
+      var html = translatePointsBalance.replace(
         'NUMBER_POINTS',
         ` <span class="smile-points-balance">' ${customerPointsBalance} '</span> `
       );
 
-      translatePointsBalance = translatePointsBalance.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translatePointsBalance;
+      return html.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
    var generateRedeemAmountLabelHtml = function(initialSliderValue) {
-      translateRedeemPoints = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
-      translateRedeemPoints = translateRedeemPoints.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
-      return translateRedeemPoints;
+      var html = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
+      return html.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
     }
 
     var generateFormattedRewardValue = function(value) {

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -3,6 +3,9 @@
      this file in place of using RangeTouch's CDN. -->
 <script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
+<!-- A third party library for formatting currencies in multiple locales -->
+<script type="https://cdnjs.com/libraries/currencyformatter.js"></script>
+
 <script src="https://js.smile.io/v1/smile-shopify.js"></script>
 
 <!-- NOTE: Your theme may or may not come with jQuery, if not
@@ -21,9 +24,15 @@
      */
     var pointsProductId = null;
     // Store's currency symbol
-    var currencySymbol = '$';
-    // Currency placement. Can be 'before' or 'after'.
-    var currencyPlacement = 'before';
+    var currencyCode = 'USD';
+
+    // Store's currency display type. Can be 'symbol' or 'code'
+    // ex: 'symbol' results in "$15"
+    // ex: 'display' results in "15 USD"
+    var currencyDisplayType = 'symbol';
+
+    // The name used for points in your reward program.
+    var pointsLabel = 'points';
 
     if (!pointsProductId) {
       console.error('The Smile.io pointsProductId has not been set. Please set this variable in order to show the points slider at checkout. Learn more at https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout.');
@@ -60,11 +69,15 @@
      * currency.
      */
     var generateFulfilledRewardNameFromValue = function(value) {
-      if (currencyPlacement === 'before') {
-        return currencySymbol + value + ' off';
-      } else {
-        return value + ' ' + currencySymbol + ' off';
+      var pattern = currencyDisplayType === 'code' ? '#,##0' : '!#,##0';
+      var opts = { currency: currencyCode, pattern: pattern };
+      var formatted = OSREC.CurrencyFormatter.format(value, opts);
+
+      if (currencyDisplayType === 'code') {
+        formatted = formatted + ' ' + currencyCode;
       }
+
+      return formatted + ' off';
     };
 
     /**

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -23,6 +23,7 @@
      * https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout
      */
     var pointsProductId = null;
+
     // Store's currency symbol
     var currencyCode = 'USD';
 
@@ -31,27 +32,73 @@
     // ex: 'display' results in "15 USD"
     var currencyDisplayType = 'symbol';
 
+    // Label for main button to apply their points value after using the points slider
+    var translateRedeemLabel = 'Redeem';
+
     // The name used for points in your reward program.
     var translatePointsLabel = 'points';
-
-    // Error message to display if the slider errors when applying points value.
-    var translateErrorMessage = 'Something went wrong spending your points. Please try again.';
 
     // Message when points reward has been added.
     var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
 
-    var translateYouHave = 'You have';
+    // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 
-    var translateRedeem = 'Redeem';
+    // This phrase will have NUMBER_POINTS replaced with the number of points the customer has
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'You have NUMBER_POINTS POINTS_LABEL' would show as 'You have 120 points'
+    // Do not remove `NUMBER_POINTS` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translatePointsBalance = 'You have NUMBER_POINTS POINTS_LABEL';
 
-    // Slider label for when user hasn't added enough slider points for the reward.
-    var translateRewardNameRedeemLabel = function(min, translatePointsLabel) {
-      return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
+    // This phrase will have MINIMUM_AMOUNT replaced with the number of points the customer needs to redeem.
+    // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.' would show as 'You need a minimum of 10 points to redeem.'
+    // Do not remove `MINIMUM_AMOUNT` or `POINTS_LABEL` from the phrase, this will happen automatically.
+    var translateRewardNameRedeemLabel = 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.'
+
+    // This phrase will have DISCOUNT_AMOUNT replaced with the currency amount to be discounted.
+    // Ex: 'DISCOUNT_AMOUNT off' would show as '$15 off' or '15 CAD off' depending on your preference above.
+    // Do not remove `DISCOUNT_AMOUNT` from the phrase, this will happen automatically.
+    var translatedDiscount = 'DISCOUNT_AMOUNT off';
+
+    var generateRewardNameRedeemLabel = function(min) {
+      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
+      translateRewardNameRedeemLabel = translateRewardNameRedeemLabel.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translateRewardNameRedeemLabel;
     }
 
-    // Ex: `$15 off` or `15 CAD off`
-    var translatedDiscount = function(amountFormatted) {
-      return amountFormatted + ' off';
+    var generatePointsBalanceHtml = function(customerPointsBalance) {
+      translatePointsBalance = translatePointsBalance.replace(
+        'NUMBER_POINTS',
+        ` <span class="smile-points-balance">' ${customerPointsBalance} '</span> `
+      );
+
+      translatePointsBalance = translatePointsBalance.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translatePointsBalance;
+    }
+
+   var generateRedeemAmountLabelHtml = function(initialSliderValue) {
+      translateRedeemPoints = translateRedeemPoints.replace('SLIDER_VALUE', ` <span class="smile-slider-value">' ${initialSliderValue} '</span> `);
+      translateRedeemPoints = translateRedeemPoints.replace('POINTS_LABEL', ` ${translatePointsLabel} `);
+      return translateRedeemPoints;
+    }
+
+    var generateFormattedRewardValue = function(value) {
+      var pattern = currencyDisplayType === 'code' ? '#,##0' : '!#,##0';
+      var opts = { currency: currencyCode, pattern: pattern };
+      var formatted = OSREC.CurrencyFormatter.format(value, opts);
+
+      if (currencyDisplayType === 'code') {
+        formatted = formatted + ' ' + currencyCode;
+      }
+
+      return formatted;
+    };
+
+    var generateRewardName = function(formattedValue) {
+      return translatedDiscount.replace('DISCOUNT_AMOUNT', formattedValue);
     }
 
     if (!pointsProductId) {
@@ -66,10 +113,11 @@
      */
     var buildPointsSliderOrderSummarySection = function(customer) {
       var customerPointsBalance = customer.points_balance;
+      var pointsBalanceHtml = generatePointsBalanceHtml(customerPointsBalance);
 
       var sliderContainerHtml = ' \
         <div class="order-summary__section order-summary__section--smile-points-slider"> \
-          <h3 class="smile-points-balance-heading">' + translateYouHave + '<span class="smile-points-balance">' + customerPointsBalance + '</span> ' + translatePointsLabel + '</h3> \
+          <h3 class="smile-points-balance-heading">' + pointsBalanceHtml + '</h3> \
           <div class="smile-points-slider" \
             data-points-product-id=' + pointsProductId + ' \
           ></div> \
@@ -78,23 +126,6 @@
       var $sliderContainer = $($.parseHTML(sliderContainerHtml));
 
       return $sliderContainer;
-    };
-
-    /**
-     * Create a name that will exist and update under the points slider.
-     * Developers should update this to reflect their reward value and
-     * currency.
-     */
-    var generateFulfilledRewardNameFromValue = function(value) {
-      var pattern = currencyDisplayType === 'code' ? '#,##0' : '!#,##0';
-      var opts = { currency: currencyCode, pattern: pattern };
-      var formatted = OSREC.CurrencyFormatter.format(value, opts);
-
-      if (currencyDisplayType === 'code') {
-        formatted = formatted + ' ' + currencyCode;
-      }
-
-      return translatedDiscount(formatted);
     };
 
     /**
@@ -154,10 +185,11 @@
           }
 
           var rewardValue = (initialSliderValue / step) * stepRewardValue;
-          var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
+          var rewardName = generateRewardName(generateFormattedRewardValue(rewardValue));
+          var redeemAmountLabelHtml = generateRedeemAmountLabelHtml(initialSliderValue);
 
           var sliderHtml = ' \
-            <div class="smile-redeem-amount-label">' + translateRedeem + '<span class="smile-slider-value">' + initialSliderValue + '</span> ' + translatePointsLabel + '</div> \
+            <div class="smile-redeem-amount-label">' + redeemAmountLabelHtml + '</div> \
             <div class="fieldset"> \
               <div class="field"> \
                 <div class="smile-form"> \
@@ -175,7 +207,7 @@
                   </div> \
                   <div class="smile-redeem-button-container"> \
                     <button type="submit" class="smile-redeem-button field__input-btn btn btn--default"> \
-                      <span class="btn__content">' + translateRedeem + '</span> \
+                      <span class="btn__content">' + translateRedeemLabel + '</span> \
                       <i class="btn__content shown-on-mobile icon icon--arrow"></i> \
                       <i class="btn__spinner icon icon--button-spinner"></i> \
                     </button> \
@@ -202,7 +234,7 @@
            var $redeemButton = $pointsSlider.find('.smile-redeem-button');
            var customerPointsBalance = smile.customer.points_balance;
            if (customerPointsBalance < min) {
-             $pointsSlider.find('.smile-reward-name').text(translateRewardNameRedeemLabel(min, translatePointsLabel));
+             $pointsSlider.find('.smile-reward-name').text(generateRewardNameRedeemLabel(min));
              $redeemButton.addClass('btn--disabled');
              $redeemButton.attr('disabled', true);
            }
@@ -229,7 +261,7 @@
             $pointsSlider.find('.smile-slider-value').text(sliderValue);
 
             // Update reward name based on the slider value
-            var rewardName = generateFulfilledRewardNameFromValue(rewardValue);
+            var rewardName = generateRewardName(generateFormattedRewardValue(rewardValue));
             $pointsSlider.find('.smile-reward-name').text(rewardName);
 
             /**

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -43,6 +43,7 @@
 
     // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
     // This phrase will also have POINTS_LABEL replaced with your label above.
+    // Ex: 'Redeem SLIDER_VALUE POINTS_LABEL' would show as 'Redeem 120 points'
     // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -15,19 +15,21 @@
 <script>
   (function() {
     /**
-     * REPLACE WITH THE POINTS PRODUCT FROM YOUR ACCOUNT.
+     * REPLACE THE FOLLOWING WITH THE POINTS PRODUCT AND CURRENCY FROM YOUR ACCOUNT.
      * Learn more at:
      * https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout
      */
     var pointsProductId = null;
+    // Store's currency symbol
+    var currencySymbol = '$';
+    // Currency placement. Can be 'before' or 'after'.
+    var currencyPlacement = 'before';
 
     if (!pointsProductId) {
       console.error('The Smile.io pointsProductId has not been set. Please set this variable in order to show the points slider at checkout. Learn more at https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout.');
       return;
     }
 
-    // Store's currency symbol
-    var currencySymbol = '$';
     // The name used for points in your reward program.
     var pointsLabel = 'points';
 
@@ -58,7 +60,11 @@
      * currency.
      */
     var generateFulfilledRewardNameFromValue = function(value) {
-      return currencySymbol + value + ' off';
+      if (currencyPlacement === 'before') {
+        return currencySymbol + value + ' off';
+      } else {
+        return value + ' ' + currencySymbol + ' off';
+      }
     };
 
     /**

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -4,7 +4,7 @@
 <script src="https://cdn.rangetouch.com/2.0.1/rangetouch.js"></script>
 
 <!-- A third party library for formatting currencies in multiple locales -->
-<script type="https://cdnjs.com/libraries/currencyformatter.js"></script>
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/currencyformatter.js/2.2.0/currencyFormatter.min.js"></script>
 
 <script src="https://js.smile.io/v1/smile-shopify.js"></script>
 
@@ -49,6 +49,11 @@
       return 'You need a minimum of ' + min + ' ' + translatePointsLabel + ' to redeem';
     }
 
+    // Ex: `$15 off` or `15 CAD off`
+    var translatedDiscount = function(amountFormatted) {
+      return amountFormatted + ' off';
+    }
+
     if (!pointsProductId) {
       console.error('The Smile.io pointsProductId has not been set. Please set this variable in order to show the points slider at checkout. Learn more at https://docs-next.smile.io/install-smile/shopify/guides/points-slider-at-checkout.');
       return;
@@ -89,7 +94,7 @@
         formatted = formatted + ' ' + currencyCode;
       }
 
-      return formatted + ' off';
+      return translatedDiscount(formatted);
     };
 
     /**

--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -32,33 +32,40 @@
     // ex: 'display' results in "15 USD"
     var currencyDisplayType = 'symbol';
 
+    // Optional translation:
     // Label for main button to apply their points value after using the points slider
     var translateRedeemLabel = 'Redeem';
 
+    // Optional translation:
     // The name used for points in your reward program.
     var translatePointsLabel = 'points';
 
+    // Optional translation:
     // Message when points reward has been added.
     var translateRewardAppliedLabel = 'Congrats! Your reward has been applied to the cart.';
 
+    // Optional translation:
     // This phrase will have SLIDER_VALUE replaced with the points value the customer has currently dragged the slider to
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'Redeem SLIDER_VALUE POINTS_LABEL' would show as 'Redeem 120 points'
     // Do not remove `SLIDER_VALUE` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRedeemPoints = 'Redeem SLIDER_VALUE POINTS_LABEL';
 
+    // Optional translation:
     // This phrase will have NUMBER_POINTS replaced with the number of points the customer has
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'You have NUMBER_POINTS POINTS_LABEL' would show as 'You have 120 points'
     // Do not remove `NUMBER_POINTS` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translatePointsBalance = 'You have NUMBER_POINTS POINTS_LABEL';
 
+    // Optional translation:
     // This phrase will have MINIMUM_AMOUNT replaced with the number of points the customer needs to redeem.
     // This phrase will also have POINTS_LABEL replaced with your label above.
     // Ex: 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.' would show as 'You need a minimum of 10 points to redeem.'
     // Do not remove `MINIMUM_AMOUNT` or `POINTS_LABEL` from the phrase, this will happen automatically.
     var translateRewardNameRedeemLabel = 'You need a minimum of MINIMUM_AMOUNT POINTS_LABEL to redeem.'
 
+    // Optional translation:
     // This phrase will have DISCOUNT_AMOUNT replaced with the currency amount to be discounted.
     // Ex: 'DISCOUNT_AMOUNT off' would show as '$15 off' or '15 CAD off' depending on your preference above.
     // Do not remove `DISCOUNT_AMOUNT` from the phrase, this will happen automatically.


### PR DESCRIPTION
### Description

The JIRA ticket only mentions updating the snippets to fix currency code/symbol issues, but there are related convos in [Slack](https://smileio.slack.com/archives/CQZCHA7HA/p1607611909016500) and in the [comment](https://github.com/smile-io/code-samples/pull/39#issuecomment-742740303) below to include any hard coded English strings in one place so merchants can translate them if they need to.

There will be corresponding updates to our [docs](https://docs.smile.io/docs/install-smile/shopify/points-slider-at-checkout#5-update-your-snippet-to-use-the-correct-pointsproduct-id) to instruct merchants where/how to update the new vars added in these snippet updates.

### Screenshots

The `CurrencyFormatter.format` method seems to work as expected when given different `currencyDisplayType` and `currencyCode` values:

<img width="316" alt="Screen Shot 2020-12-10 at 2 51 18 PM" src="https://user-images.githubusercontent.com/2292367/102256493-15d06d00-3ed1-11eb-9bd3-b16bbeee9507.png">

### Questions 🤔 

- Does this open up too much space for new errors since we're allowing non-dev people to customize more parts of a script that we're providing? I'm wondering if this might create more issues than it solves.
- Not really a question, but wanted to point out that the `translateRewardNameRedeemLabel` method might be a bit odd or confusing to non-devs who want to translate those strings. Not quite sure what the better option for this would be though?
