### PR TITLE
[PROD-2047] Add missing translation variable to Shopify points slider

### DIFF
--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -71,6 +71,9 @@
     // Do not remove `DISCOUNT_AMOUNT` from the phrase, this will happen automatically.
     var translatedDiscount = 'DISCOUNT_AMOUNT off';
 
+    // Optional translation:
+    var translateErrorMessage = 'Something went wrong spending your points. Please try again.';
+
     var generateRewardNameRedeemLabel = function(min) {
       var label = translateRewardNameRedeemLabel.replace('MINIMUM_AMOUNT', min);
       return label.replace('POINTS_LABEL', ` ${translatePointsLabel} `);


### PR DESCRIPTION
From [PROD-2047](https://smileio.atlassian.net/browse/PROD-2047), it looks like we missed declaring `translateErrorMessage` in #39, this just adds the variable.