### PR TITLE
[PROD-2154] Fix invisible points slider track on some stores in Firefox

### DIFF
--- a/shopify-points-slider/smile-points-slider.liquid
+++ b/shopify-points-slider/smile-points-slider.liquid
@@ -403,6 +403,7 @@
     /* Fixes shopify checkout */
     -moz-appearance: range !important;
     -webkit-appearance: slider-horizontal !important;
+    appearance: auto !important;
   }
 
   @media (max-width: 767px) {

--- a/shopify-points-slider/sweettooth-points-slider.liquid
+++ b/shopify-points-slider/sweettooth-points-slider.liquid
@@ -319,6 +319,7 @@
     /* Fixes shopify checkout */
     -moz-appearance: range !important;
     -webkit-appearance: slider-horizontal !important;
+    appearance: auto !important;
   }
 
   @media (max-width: 767px) {


### PR DESCRIPTION
JIRA issue: [PROD-2154](https://smileio.atlassian.net/browse/PROD-2154)

Fixes an issue where the track on the points slider was not showing on some Shopify stores on Firefox.